### PR TITLE
Request-wise validation

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/HeaderValidationResult.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/HeaderValidationResult.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+public interface HeaderValidationResult {
+    HeaderValidationResult OK = new HeaderValidationResult() {
+    };
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -22,8 +22,8 @@ import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpContentDecompressor;
-import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseEncoder;
@@ -146,7 +146,8 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
     private final RecvByteBufAllocator recvByteBufAllocator;
     private final TLSConfig tlsConfig;
     private final AcceptChannelHandler.AcceptPredicate acceptChannelPredicate;
-    private final BiConsumer<HttpMessage, ActionListener<Void>> headerValidator = null;
+    private final BiConsumer<HttpRequest, ActionListener<ValidatedHttpRequest>> headerValidator = (httpRequest, listener) -> listener
+        .onResponse(ValidatedHttpRequest.decorateOK(httpRequest));
     private final int readTimeoutMillis;
 
     private final int maxCompositeBufferComponents;
@@ -339,14 +340,14 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
         private final HttpHandlingSettings handlingSettings;
         private final TLSConfig tlsConfig;
         private final BiPredicate<String, InetSocketAddress> acceptChannelPredicate;
-        private final BiConsumer<HttpMessage, ActionListener<Void>> headerValidator;
+        private final BiConsumer<HttpRequest, ActionListener<ValidatedHttpRequest>> headerValidator;
 
         protected HttpChannelHandler(
             final Netty4HttpServerTransport transport,
             final HttpHandlingSettings handlingSettings,
             final TLSConfig tlsConfig,
             @Nullable final BiPredicate<String, InetSocketAddress> acceptChannelPredicate,
-            @Nullable final BiConsumer<HttpMessage, ActionListener<Void>> headerValidator
+            @Nullable final BiConsumer<HttpRequest, ActionListener<ValidatedHttpRequest>> headerValidator
         ) {
             this.transport = transport;
             this.handlingSettings = handlingSettings;
@@ -381,11 +382,8 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                 handlingSettings.maxChunkSize()
             );
             decoder.setCumulator(ByteToMessageDecoder.COMPOSITE_CUMULATOR);
-            if (headerValidator != null) {
-                ch.pipeline().addLast(new Netty4HttpHeaderValidator(headerValidator));
-            }
-
-            final HttpObjectAggregator aggregator = new HttpObjectAggregator(handlingSettings.maxContentLength());
+            Netty4HttpHeaderValidator validator = new Netty4HttpHeaderValidator(headerValidator);
+            final HttpObjectAggregator aggregator = new ValidatedHttpObjectAggregator(handlingSettings.maxContentLength());
             aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
             ch.pipeline()
                 .addLast("decoder", decoder)

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/ValidatedFullHttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/ValidatedFullHttpRequest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+public class ValidatedFullHttpRequest implements FullHttpRequest {
+
+    private final FullHttpRequest fullHttpRequest;
+
+    private final HeaderValidationResult validationResult;
+    private HttpHeaders trailingHeaders;
+
+    public ValidatedFullHttpRequest(FullHttpRequest fullHttpRequest, HeaderValidationResult validationResult) {
+        this.fullHttpRequest = fullHttpRequest;
+        this.validationResult = validationResult;
+        this.trailingHeaders = fullHttpRequest.trailingHeaders();
+    }
+
+    public HeaderValidationResult validationResult() {
+        return validationResult;
+    }
+
+    void setTrailingHeaders(HttpHeaders trailingHeaders) {
+        this.trailingHeaders = trailingHeaders;
+    }
+
+    @Override
+    public ByteBuf content() {
+        return this.fullHttpRequest.content();
+    }
+
+    @Override
+    public HttpHeaders trailingHeaders() {
+        HttpHeaders trailingHeaders = this.trailingHeaders;
+        if (trailingHeaders == null) {
+            return EmptyHttpHeaders.INSTANCE;
+        } else {
+            return trailingHeaders;
+        }
+    }
+
+    @Override
+    public FullHttpRequest copy() {
+        return new ValidatedFullHttpRequest(this.fullHttpRequest.copy(), this.validationResult);
+    }
+
+    @Override
+    public FullHttpRequest duplicate() {
+        return new ValidatedFullHttpRequest(this.fullHttpRequest.duplicate(), this.validationResult);
+    }
+
+    @Override
+    public FullHttpRequest retainedDuplicate() {
+        return new ValidatedFullHttpRequest(this.fullHttpRequest.retainedDuplicate(), this.validationResult);
+    }
+
+    @Override
+    public FullHttpRequest replace(ByteBuf content) {
+        return new ValidatedFullHttpRequest(this.fullHttpRequest.replace(content), this.validationResult);
+    }
+
+    @Override
+    public FullHttpRequest retain(int increment) {
+        this.fullHttpRequest.retain(increment);
+        return this;
+    }
+
+    @Override
+    public int refCnt() {
+        return this.fullHttpRequest.refCnt();
+    }
+
+    @Override
+    public FullHttpRequest retain() {
+        this.fullHttpRequest.retain();
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest touch() {
+        this.fullHttpRequest.touch();
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest touch(Object hint) {
+        this.fullHttpRequest.touch(hint);
+        return this;
+    }
+
+    @Override
+    public boolean release() {
+        return this.fullHttpRequest.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return this.fullHttpRequest.release(decrement);
+    }
+
+    @Override
+    public HttpVersion getProtocolVersion() {
+        return this.fullHttpRequest.getProtocolVersion();
+    }
+
+    @Override
+    public HttpVersion protocolVersion() {
+        return this.fullHttpRequest.protocolVersion();
+    }
+
+    @Override
+    public FullHttpRequest setProtocolVersion(HttpVersion version) {
+        this.fullHttpRequest.setProtocolVersion(version);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return this.fullHttpRequest.headers();
+    }
+
+    @Override
+    public HttpMethod getMethod() {
+        return this.fullHttpRequest.getMethod();
+    }
+
+    @Override
+    public HttpMethod method() {
+        return this.fullHttpRequest.method();
+    }
+
+    @Override
+    public FullHttpRequest setMethod(HttpMethod method) {
+        this.fullHttpRequest.setMethod(method);
+        return this;
+    }
+
+    @Override
+    public String getUri() {
+        return this.fullHttpRequest.getUri();
+    }
+
+    @Override
+    public String uri() {
+        return this.fullHttpRequest.uri();
+    }
+
+    @Override
+    public FullHttpRequest setUri(String uri) {
+        this.fullHttpRequest.setUri(uri);
+        return this;
+    }
+
+    @Override
+    public DecoderResult getDecoderResult() {
+        return this.fullHttpRequest.getDecoderResult();
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return this.fullHttpRequest.decoderResult();
+    }
+
+    @Override
+    public void setDecoderResult(DecoderResult result) {
+        this.fullHttpRequest.setDecoderResult(result);
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/ValidatedHttpObjectAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/ValidatedHttpObjectAggregator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.LastHttpContent;
+
+public class ValidatedHttpObjectAggregator extends HttpObjectAggregator {
+
+    public ValidatedHttpObjectAggregator(int maxContentLength) {
+        super(maxContentLength);
+    }
+
+    @Override
+    protected FullHttpMessage beginAggregation(HttpMessage start, ByteBuf content) throws Exception {
+        FullHttpMessage aggregatingMessage = super.beginAggregation(start, content);
+        if (start instanceof ValidatedHttpRequest && aggregatingMessage instanceof FullHttpRequest) {
+            return new ValidatedFullHttpRequest((FullHttpRequest) aggregatingMessage, ((ValidatedHttpRequest) start).validationResult());
+        } else {
+            return aggregatingMessage;
+        }
+    }
+
+    @Override
+    protected void aggregate(FullHttpMessage aggregated, HttpContent content) throws Exception {
+        if (content instanceof LastHttpContent) {
+            // Merge trailing headers into the message.
+            if (aggregated instanceof ValidatedFullHttpRequest) {
+                ((ValidatedFullHttpRequest) aggregated).setTrailingHeaders(((LastHttpContent) content).trailingHeaders());
+            }
+        }
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/ValidatedHttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/ValidatedHttpRequest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+
+public class ValidatedHttpRequest implements HttpRequest {
+
+    // decorated instance
+    private final HttpRequest httpRequest;
+    private final HeaderValidationResult validationResult;
+
+    public static ValidatedHttpRequest decorateOK(HttpRequest httpRequest) {
+        return new ValidatedHttpRequest(httpRequest, HeaderValidationResult.OK);
+    }
+
+    private ValidatedHttpRequest(HttpRequest httpRequest, HeaderValidationResult validationResult) {
+        this.httpRequest = httpRequest;
+        this.validationResult = validationResult;
+    }
+
+    public HeaderValidationResult validationResult() {
+        return validationResult;
+    }
+
+    // TODO remove this
+    public HttpRequest httpRequest() {
+        return httpRequest;
+    }
+
+    @Override
+    public HttpMethod getMethod() {
+        return httpRequest.getMethod();
+    }
+
+    @Override
+    public HttpMethod method() {
+        return httpRequest.method();
+    }
+
+    @Override
+    public HttpRequest setMethod(HttpMethod method) {
+        return httpRequest.setMethod(method);
+    }
+
+    @Override
+    public String getUri() {
+        return httpRequest.getUri();
+    }
+
+    @Override
+    public String uri() {
+        return httpRequest.uri();
+    }
+
+    @Override
+    public HttpRequest setUri(String uri) {
+        return httpRequest.setUri(uri);
+    }
+
+    @Override
+    public HttpVersion getProtocolVersion() {
+        return httpRequest.getProtocolVersion();
+    }
+
+    @Override
+    public HttpVersion protocolVersion() {
+        return httpRequest.protocolVersion();
+    }
+
+    @Override
+    public HttpRequest setProtocolVersion(HttpVersion version) {
+        httpRequest.setProtocolVersion(version);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return httpRequest.headers();
+    }
+
+    @Override
+    public DecoderResult getDecoderResult() {
+        return httpRequest.getDecoderResult();
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return httpRequest.decoderResult();
+    }
+
+    @Override
+    public void setDecoderResult(DecoderResult result) {
+        httpRequest.setDecoderResult(result);
+    }
+}

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -376,7 +376,13 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
             ) {
                 @Override
                 public ChannelHandler configureServerChannelHandler() {
-                    return new HttpChannelHandler(this, handlingSettings, TLSConfig.noTLS(), null, null) {
+                    return new HttpChannelHandler(
+                        this,
+                        handlingSettings,
+                        TLSConfig.noTLS(),
+                        null,
+                        (httpRequest, listener) -> listener.onResponse(ValidatedHttpRequest.decorateOK(httpRequest))
+                    ) {
                         @Override
                         protected void initChannel(Channel ch) throws Exception {
                             super.initChannel(ch);


### PR DESCRIPTION
This is a POC for attaching the HTTP header validation result to the http request(s) that flow through the netty pipeline.
Based on: https://github.com/Tim-Brooks/elasticsearch/tree/early_http_header_check