### PR TITLE
Header-wise validation

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/HeadersValidationResult.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/HeadersValidationResult.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+public interface HeadersValidationResult {
+
+    HeadersValidationResult OK = new HeadersValidationResult() {
+    };
+
+    HeadersValidationResult NOK = new HeadersValidationResult() {
+    };
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/HeadersWithValidationResult.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/HeadersWithValidationResult.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+
+import org.apache.lucene.util.SetOnce;
+
+public class HeadersWithValidationResult extends DefaultHttpHeaders {
+
+    private final SetOnce<HeadersValidationResult> validationResult = new SetOnce<>();
+
+    public static DefaultHttpRequest wrapRequestWithValidatableHeaders(DefaultHttpRequest originalRequest, boolean validateHeaders) {
+        HeadersWithValidationResult httpHeaders = new HeadersWithValidationResult(originalRequest.headers(), validateHeaders);
+        return new DefaultHttpRequest(originalRequest.protocolVersion(), originalRequest.method(), originalRequest.uri(), httpHeaders);
+    }
+
+    public HeadersWithValidationResult(HttpHeaders httpHeaders, boolean validateHeaders) {
+        super(validateHeaders);
+        add(httpHeaders);
+    }
+
+    public HeadersValidationResult getValidationResult() {
+        return validationResult.get();
+    }
+
+    public void setValidationResult(HeadersValidationResult validationResult) {
+        this.validationResult.set(validationResult);
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpHeaderValidator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpHeaderValidator.java
@@ -16,6 +16,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
 
@@ -76,19 +77,21 @@ public class Netty4HttpHeaderValidator extends ChannelInboundHandlerAdapter {
     private void requestStart(ChannelHandlerContext ctx) {
         assert pending.isEmpty() == false;
 
-        HttpObject httpObject = pending.getFirst();
-        assert httpObject instanceof HttpMessage;
+        HttpRequest httpRequest = (HttpRequest) pending.getFirst();
+        assert httpRequest.headers() instanceof HeadersWithValidationResult;
+        assert ((HeadersWithValidationResult) httpRequest.headers()).getValidationResult() == null;
         // We failed in the decoding step for other reasons. Pass down the pipeline.
-        if (httpObject.decoderResult().isFailure()) {
+        if (httpRequest.decoderResult().isFailure()) {
             ctx.fireChannelRead(pending.pollFirst());
             return;
         }
 
         state = STATE.QUEUEING_DATA;
-        validator.accept((HttpMessage) httpObject, new ActionListener<>() {
+        validator.accept(httpRequest, new ActionListener<>() {
             @Override
             public void onResponse(Void unused) {
                 // Always use "Submit" to prevent reentrancy concerns if we are still on event loop
+                ((HeadersWithValidationResult) httpRequest.headers()).setValidationResult(HeadersValidationResult.OK);
                 ctx.channel().eventLoop().submit(() -> validationSuccess(ctx));
             }
 
@@ -102,6 +105,7 @@ public class Netty4HttpHeaderValidator extends ChannelInboundHandlerAdapter {
                 } else {
                     toForward = new HeaderValidationException(new ElasticsearchException(e), true);
                 }
+                ((HeadersWithValidationResult) httpRequest.headers()).setValidationResult(HeadersValidationResult.NOK);
                 // Always use "Submit" to prevent reentrancy concerns if we are still on event loop
                 ctx.channel().eventLoop().submit(() -> validationFailure(ctx, toForward));
             }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -20,6 +20,7 @@ import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpMessage;
@@ -146,7 +147,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
     private final RecvByteBufAllocator recvByteBufAllocator;
     private final TLSConfig tlsConfig;
     private final AcceptChannelHandler.AcceptPredicate acceptChannelPredicate;
-    private final BiConsumer<HttpMessage, ActionListener<Void>> headerValidator = null;
+    private final BiConsumer<HttpMessage, ActionListener<Void>> headerValidator = (message, listener) -> listener.onResponse(null);
     private final int readTimeoutMillis;
 
     private final int maxCompositeBufferComponents;
@@ -379,7 +380,19 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                 handlingSettings.maxInitialLineLength(),
                 handlingSettings.maxHeaderSize(),
                 handlingSettings.maxChunkSize()
-            );
+            ) {
+                @Override
+                protected HttpMessage createMessage(String[] initialLine) throws Exception {
+                    DefaultHttpRequest httpRequest = (DefaultHttpRequest) super.createMessage(initialLine);
+                    return HeadersWithValidationResult.wrapRequestWithValidatableHeaders(httpRequest, validateHeaders);
+                }
+
+                @Override
+                protected HttpMessage createInvalidMessage() {
+                    DefaultHttpRequest httpRequest = (DefaultHttpRequest) super.createInvalidMessage();
+                    return HeadersWithValidationResult.wrapRequestWithValidatableHeaders(httpRequest, validateHeaders);
+                }
+            };
             decoder.setCumulator(ByteToMessageDecoder.COMPOSITE_CUMULATOR);
             if (headerValidator != null) {
                 ch.pipeline().addLast(new Netty4HttpHeaderValidator(headerValidator));

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpHeaderValidatorTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpHeaderValidatorTests.java
@@ -60,7 +60,10 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
     public void testValidationPausesAndResumesData() {
         assertTrue(channel.config().isAutoRead());
 
-        final DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        DefaultHttpRequest request = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         DefaultHttpContent content = new DefaultHttpContent(Unpooled.buffer(4));
         channel.writeInbound(request);
         channel.writeInbound(content);
@@ -77,6 +80,7 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
         assertThat(channel.readInbound(), sameInstance(content));
         assertThat(channel.readInbound(), nullValue());
         assertThat(content.refCnt(), equalTo(1));
+        assertThat(((HeadersWithValidationResult) request.headers()).getValidationResult(), equalTo(HeadersValidationResult.OK));
 
         DefaultLastHttpContent lastContent = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
         channel.writeInbound(lastContent);
@@ -85,13 +89,20 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
         assertThat(channel.readInbound(), sameInstance(lastContent));
         assertThat(lastContent.refCnt(), equalTo(1));
 
+        request = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         channel.writeInbound(request);
         assertFalse(channel.config().isAutoRead());
         assertThat(netty4HttpHeaderValidator.getState(), equalTo(Netty4HttpHeaderValidator.STATE.QUEUEING_DATA));
     }
 
     public void testValidationErrorForwardsAsDecoderErrorMessage() {
-        final DefaultHttpRequest request1 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        final DefaultHttpRequest request1 = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         DefaultHttpContent content = new DefaultHttpContent(Unpooled.buffer(4));
         channel.writeInbound(request1);
         channel.writeInbound(content);
@@ -107,6 +118,7 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
         DefaultHttpRequest failed = channel.readInbound();
         assertThat(failed, sameInstance(request1));
         assertThat(failed.headers().get(HttpHeaderNames.CONNECTION), equalTo(HttpHeaderValues.CLOSE.toString()));
+        assertThat(((HeadersWithValidationResult) failed.headers()).getValidationResult(), equalTo(HeadersValidationResult.NOK));
         assertTrue(failed.decoderResult().isFailure());
         HeaderValidationException cause = (HeaderValidationException) failed.decoderResult().cause();
         assertThat(cause.getCause().getCause(), equalTo(failure));
@@ -114,7 +126,10 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
         assertThat(netty4HttpHeaderValidator.getState(), equalTo(Netty4HttpHeaderValidator.STATE.DROPPING_DATA_PERMANENTLY));
 
         reset();
-        final DefaultHttpRequest request2 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        final DefaultHttpRequest request2 = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         channel.writeInbound(request2);
         channel.writeInbound(content);
 
@@ -125,6 +140,7 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
         failed = channel.readInbound();
         assertThat(failed, sameInstance(request2));
         assertThat(failed.headers().get(HttpHeaderNames.CONNECTION), equalTo(HttpHeaderValues.CLOSE.toString()));
+        assertThat(((HeadersWithValidationResult) failed.headers()).getValidationResult(), equalTo(HeadersValidationResult.NOK));
         assertTrue(failed.decoderResult().isFailure());
         cause = (HeaderValidationException) failed.decoderResult().cause();
         assertThat(failed.decoderResult().cause().getCause(), equalTo(elasticsearchFailure));
@@ -132,7 +148,10 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
         assertThat(netty4HttpHeaderValidator.getState(), equalTo(Netty4HttpHeaderValidator.STATE.DROPPING_DATA_PERMANENTLY));
 
         reset();
-        final DefaultHttpRequest request3 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        final DefaultHttpRequest request3 = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         channel.writeInbound(request3);
         channel.writeInbound(content);
 
@@ -142,6 +161,7 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
         failed = channel.readInbound();
         assertThat(failed, sameInstance(request3));
         assertThat(failed.headers().get(HttpHeaderNames.CONNECTION), nullValue());
+        assertThat(((HeadersWithValidationResult) failed.headers()).getValidationResult(), equalTo(HeadersValidationResult.NOK));
         assertTrue(failed.decoderResult().isFailure());
         cause = (HeaderValidationException) failed.decoderResult().cause();
         assertThat(failed.decoderResult().cause().getCause(), equalTo(elasticsearchFailure));
@@ -152,13 +172,19 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
     public void testValidationHandlesMultipleQueuedUpMessages() {
         assertTrue(channel.config().isAutoRead());
 
-        final DefaultHttpRequest request1 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        final DefaultHttpRequest request1 = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         DefaultHttpContent content1 = new DefaultHttpContent(Unpooled.buffer(4));
         DefaultLastHttpContent lastContent1 = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
         channel.writeInbound(request1);
         channel.writeInbound(content1);
         channel.writeInbound(lastContent1);
-        final DefaultHttpRequest request2 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        final DefaultHttpRequest request2 = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         DefaultHttpContent content2 = new DefaultHttpContent(Unpooled.buffer(4));
         DefaultLastHttpContent lastContent2 = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
         channel.writeInbound(request2);
@@ -175,6 +201,7 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
         assertThat(channel.readInbound(), sameInstance(content1));
         assertThat(channel.readInbound(), sameInstance(lastContent1));
         assertThat(content1.refCnt(), equalTo(1));
+        assertThat(((HeadersWithValidationResult) request1.headers()).getValidationResult(), equalTo(HeadersValidationResult.OK));
 
         assertThat(header.get(), sameInstance(request2));
 
@@ -188,6 +215,7 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
         assertThat(channel.readInbound(), sameInstance(content2));
         assertThat(channel.readInbound(), sameInstance(lastContent2));
         assertThat(content2.refCnt(), equalTo(1));
+        assertThat(((HeadersWithValidationResult) request2.headers()).getValidationResult(), equalTo(HeadersValidationResult.OK));
 
         assertTrue(channel.config().isAutoRead());
         assertThat(netty4HttpHeaderValidator.getState(), equalTo(Netty4HttpHeaderValidator.STATE.WAITING_TO_START));
@@ -197,7 +225,10 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
     public void testValidationFailureWithNoRecovery() {
         assertTrue(channel.config().isAutoRead());
 
-        final DefaultHttpRequest request1 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        final DefaultHttpRequest request1 = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         DefaultHttpContent content1 = new DefaultHttpContent(Unpooled.buffer(4));
         DefaultLastHttpContent lastContent1 = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
         channel.writeInbound(request1);
@@ -233,13 +264,19 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
     public void testValidationFailureCanRecover() {
         assertTrue(channel.config().isAutoRead());
 
-        final DefaultHttpRequest request1 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        final DefaultHttpRequest request1 = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         DefaultHttpContent content1 = new DefaultHttpContent(Unpooled.buffer(4));
         DefaultLastHttpContent lastContent1 = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
         channel.writeInbound(request1);
         channel.writeInbound(content1);
         channel.writeInbound(lastContent1);
-        final DefaultHttpRequest request2 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        final DefaultHttpRequest request2 = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         DefaultHttpContent content2 = new DefaultHttpContent(Unpooled.buffer(4));
         DefaultLastHttpContent lastContent2 = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
         channel.writeInbound(request2);
@@ -289,14 +326,22 @@ public class Netty4HttpHeaderValidatorTests extends ESTestCase {
     public void testValidatorWithLargeMessage() {
         assertTrue(channel.config().isAutoRead());
 
-        final DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri");
+        final DefaultHttpRequest request = HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+            true
+        );
         channel.writeInbound(request);
 
         for (int i = 0; i < 64; ++i) {
             channel.writeInbound(new DefaultHttpContent(Unpooled.buffer(4)));
         }
         channel.writeInbound(new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER));
-        channel.writeInbound(request);
+        channel.writeInbound(
+            HeadersWithValidationResult.wrapRequestWithValidatableHeaders(
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri"),
+                true
+            )
+        );
 
         assertThat(header.get(), sameInstance(request));
         assertThat(channel.readInbound(), nullValue());


### PR DESCRIPTION
This is a POC for attaching the HTTP header validation result to the http headers which are part of the http requests that pass through the netty pipeline.

Based on: https://github.com/Tim-Brooks/elasticsearch/tree/early_http_header_check

Related:
https://github.com/albertzaharovits/elasticsearch/pull/1